### PR TITLE
Fix CVE-2025-30167: upgrade jupyter_core from 5.3.1 to 5.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ jsonschema==4.17.3
 jupyter-console==6.6.3
 jupyter-events==0.6.3
 jupyter_client==8.2.0
-jupyter_core==5.3.1
+jupyter_core==5.8.1
 jupyter_server==2.14.1
 jupyter_server_terminals==0.4.4
 jupyterlab-pygments==0.2.2


### PR DESCRIPTION
Resolves Dependabot alert #17 (GHSA-33p9-3p43-82vq / CVE-2025-30167): jupyter_core < 5.8.0 has a local privilege escalation vulnerability on Windows via uncontrolled search path in %PROGRAMDATA% for config files.

https://claude.ai/code/session_019g4QCLqBAwnDnGgKEG2PnU